### PR TITLE
close Opened file descriptor and check hidden file(start with .)

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -55,6 +55,7 @@ func New(dirPath string) (*Cache, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer dir.Close()
 	fis, err := dir.Readdir(0)
 	if err != nil {
 		return nil, err
@@ -64,6 +65,10 @@ func New(dirPath string) (*Cache, error) {
 		c.size += fi.Size()
 		name := fi.Name()
 		id := strings.Split(name, ".")[0]
+		if id == "" {
+			log.Println("hidden file ", name)
+			continue
+		}
 		c.files[id] = fi
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,7 @@ func Load() (*Config, error) {
 	conf := Default
 
 	confFile, err := os.Open(confPath)
+	defer confFile.Close()
 	if err != nil {
 		if os.IsNotExist(err) {
 			mu.RUnlock()


### PR DESCRIPTION
Hi moshee:
1. I find 2 opened file descriptor miss closed, one of them was in a mutex, I think that won't cause a problem, since I modify the code, and run again without exception.

2.  when genarate Cache struct,  there may be some hidden files whose filename start with .   , and we shouldn't put them into the map, because the key is  empty string